### PR TITLE
Throw AravisException instead of Exception when camera cannot create stream

### DIFF
--- a/aravis.py
+++ b/aravis.py
@@ -41,7 +41,7 @@ class Camera(object):
         self.dev = self.cam.get_device()
         self.stream = self.cam.create_stream(None, None)
         if self.stream is None:
-            raise Exception("Error creating buffer")
+            raise AravisException("Error creating buffer")
         self._frame = None
         self._last_payload = 0
 


### PR DESCRIPTION
This makes it easier for clients to catch and handle camera related exceptions.
