### PR TITLE
Added cleanup stuff to prevent the GigE socket from staying opened!

### DIFF
--- a/aravis.py
+++ b/aravis.py
@@ -231,7 +231,10 @@ class Camera(object):
         self.cam.stop_acquisition()
 
     def shutdown(self):
-        self.logger.warning("It is not necessary to call shutdown in this version of python-aravis")
+	#Delete the objects on shutdown: socket will be closed!
+        del self.stream
+        del self.dev
+        del self.cam
 
 
 


### PR DESCRIPTION
I had the problem that my camera was blocked after using the minimal script once.
So I inserted some cleanup which will close the network socket.

Tested with:
Debian 9.9
Aravis 0.6
Leutron Vision-PicSight G123B-GigE